### PR TITLE
Enhance Figma plugin manifest with network access permissions and update navigation links

### DIFF
--- a/apps/figma-plugin/manifest.dev.json
+++ b/apps/figma-plugin/manifest.dev.json
@@ -8,5 +8,15 @@
   "enableProposedApi": false,
   "documentAccess": "dynamic-page",
   "editorType": ["figma"],
-  "permissions": ["teamlibrary", "currentuser"]
+  "permissions": ["teamlibrary", "currentuser"],
+  "networkAccess": {
+    "allowedDomains": [
+      "https://api.recursica.com",
+      "https://fonts.googleapis.com",
+      "https://raw.githubusercontent.com",
+      "https://api.github.com",
+      "https://gitlab.com"
+    ],
+    "devAllowedDomains": ["http://localhost:5173", "https://dev-api.recursica.com"]
+  }
 }

--- a/apps/figma-plugin/manifest.json
+++ b/apps/figma-plugin/manifest.json
@@ -7,5 +7,15 @@
   "enableProposedApi": false,
   "documentAccess": "dynamic-page",
   "editorType": ["figma"],
-  "permissions": ["teamlibrary", "currentuser"]
+  "permissions": ["teamlibrary", "currentuser"],
+  "networkAccess": {
+    "allowedDomains": [
+      "https://api.recursica.com",
+      "https://fonts.googleapis.com",
+      "https://raw.githubusercontent.com",
+      "https://api.github.com",
+      "https://gitlab.com"
+    ],
+    "devAllowedDomains": ["http://localhost:5173", "https://dev-api.recursica.com"]
+  }
 }

--- a/apps/figma-plugin/src/pages/Auth/Auth.tsx
+++ b/apps/figma-plugin/src/pages/Auth/Auth.tsx
@@ -182,7 +182,7 @@ export function Auth() {
           <Button
             size='small'
             variant='text'
-            icon='arrow_path_outline'
+            icon='arrow_left_outline'
             onClick={() => navigate('/home')}
             label='Back'
           />

--- a/apps/figma-plugin/src/pages/Error/Error.tsx
+++ b/apps/figma-plugin/src/pages/Error/Error.tsx
@@ -22,7 +22,7 @@ export function Error() {
       footer={
         <Button
           component={NavLink}
-          to='https://recursica.com'
+          to='https://www.recursica.com/community'
           target='_blank'
           rel='noopener noreferrer'
           label='Learn more'

--- a/apps/figma-plugin/src/pages/PublishChanges/PublishChanges.tsx
+++ b/apps/figma-plugin/src/pages/PublishChanges/PublishChanges.tsx
@@ -200,7 +200,8 @@ export function PublishChanges() {
               variant='outline'
               label='Send bug'
               component={Anchor}
-              href='https://github.com/recursica/figma-plugin/issues'
+              underline='never'
+              href='https://www.recursica.com/community'
               target='_blank'
               rel='noopener noreferrer'
               leading='flag_outline'


### PR DESCRIPTION
- Added `networkAccess` configuration to both `manifest.dev.json` and `manifest.json`, specifying allowed and development domains.
- Changed the back button icon in the Auth page from 'arrow_path_outline' to 'arrow_left_outline'.
- Updated the error page link to direct users to the community page instead of the main site.
- Modified the PublishChanges page link to point to the community page for bug reporting.