### PR TITLE
Fix Button loading state icon offset from brand line-height token

### DIFF
--- a/.changeset/funny-oranges-agree.md
+++ b/.changeset/funny-oranges-agree.md
@@ -1,0 +1,5 @@
+---
+"@recursica/mantine-adapter": minor
+---
+
+Fix Button loading state loader offset caused by brand line-height

--- a/packages/mantine-adapter/src/components/Button/Button.module.css
+++ b/packages/mantine-adapter/src/components/Button/Button.module.css
@@ -31,9 +31,6 @@
   letter-spacing: var(
     --recursica_ui-kit_components_button_variants_sizes_default_properties_text_letter-spacing
   );
-  line-height: var(
-    --recursica_ui-kit_components_button_variants_sizes_default_properties_text_line-height
-  );
   text-decoration: var(
     --recursica_ui-kit_components_button_variants_sizes_default_properties_text_text-decoration
   );
@@ -68,7 +65,15 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: inherit;
-  line-height: inherit;
+  line-height: var(
+    --recursica_ui-kit_components_button_variants_sizes_default_properties_text_line-height
+  );
+}
+
+.root[data-size="small"] .labelText {
+  line-height: var(
+    --recursica_ui-kit_components_button_variants_sizes_small_properties_text_line-height
+  );
 }
 
 /* ==== SIZES ==== */
@@ -197,9 +202,6 @@
   );
   letter-spacing: var(
     --recursica_ui-kit_components_button_variants_sizes_small_properties_text_letter-spacing
-  );
-  line-height: var(
-    --recursica_ui-kit_components_button_variants_sizes_small_properties_text_line-height
   );
   text-decoration: var(
     --recursica_ui-kit_components_button_variants_sizes_small_properties_text_text-decoration


### PR DESCRIPTION
Moves line-height brand token off the button root onto .labelText only.
Mantine sets line-height: 1 on the button root intentionally to keep the loader wrapper's line box equal to the spinner's visual size. Recursica was overriding this with the brand token on .root, which caused the loader to appear vertically offset in brands with large line-height values (e.g. 1.6em vs 1.05em in the default brand).